### PR TITLE
Specify price for Market buy orders when required by exchange

### DIFF
--- a/packages/backtesting/src/exchange/memory-exchange.ts
+++ b/packages/backtesting/src/exchange/memory-exchange.ts
@@ -101,6 +101,21 @@ export class MemoryExchange implements IExchange {
     };
   }
 
+  async getTicker(symbol: string): Promise<ITicker> {
+    const candlestick = this.marketSimulator.currentCandle;
+    const assetPrice = candlestick.close;
+
+    return {
+      symbol,
+      bid: assetPrice,
+      ask: assetPrice,
+      last: assetPrice,
+      baseVolume: 0,
+      quoteVolume: 0,
+      timestamp: this.marketSimulator.currentCandle.timestamp,
+    };
+  }
+
   async getMarketPrice(params: IGetMarketPriceRequest): Promise<IGetMarketPriceResponse> {
     const candlestick = this.marketSimulator.currentCandle;
     const assetPrice = candlestick.close;

--- a/packages/backtesting/src/exchange/memory-exchange.ts
+++ b/packages/backtesting/src/exchange/memory-exchange.ts
@@ -9,20 +9,22 @@ import type {
   IGetMarketPriceResponse,
   ICancelLimitOrderRequest,
   ICancelLimitOrderResponse,
-  IGetLimitOrderRequest,
-  IGetLimitOrderResponse,
+  IPlaceOrderRequest,
+  IPlaceOrderResponse,
   IPlaceLimitOrderRequest,
   IPlaceLimitOrderResponse,
+  IPlaceMarketOrderRequest,
+  IPlaceMarketOrderResponse,
+  IPlaceStopOrderRequest,
+  IPlaceStopOrderResponse,
+  IGetLimitOrderRequest,
+  IGetLimitOrderResponse,
   IGetSymbolInfoRequest,
   ISymbolInfo,
   IWatchOrdersRequest,
   IWatchOrdersResponse,
-  IPlaceStopOrderRequest,
-  IPlaceStopOrderResponse,
   IWatchCandlesRequest,
   IWatchCandlesResponse,
-  IPlaceMarketOrderRequest,
-  IPlaceMarketOrderResponse,
   ITrade,
   IOrderbook,
   ITicker,
@@ -62,6 +64,13 @@ export class MemoryExchange implements IExchange {
       createdAt: 0,
       lastTradeTimestamp: 0,
       filledPrice: null,
+    };
+  }
+
+  async placeOrder(_body: IPlaceOrderRequest): Promise<IPlaceOrderResponse> {
+    return {
+      orderId: "",
+      clientOrderId: "",
     };
   }
 

--- a/packages/exchanges/src/exchanges/ccxt/exchange.ts
+++ b/packages/exchanges/src/exchanges/ccxt/exchange.ts
@@ -171,6 +171,13 @@ export class CCXTExchange implements IExchange {
     };
   }
 
+  async getTicker(symbol: string): Promise<ITicker> {
+    const args = normalize.getTicker.request(symbol);
+    const data = await this.ccxt.fetchTicker(...args);
+
+    return normalize.getTicker.response(data);
+  }
+
   async getMarketPrice(params: IGetMarketPriceRequest): Promise<IGetMarketPriceResponse> {
     const args = normalize.getMarketPrice.request(params);
     const data = await this.ccxt.fetchTicker(...args);

--- a/packages/exchanges/src/exchanges/ccxt/exchange.ts
+++ b/packages/exchanges/src/exchanges/ccxt/exchange.ts
@@ -30,6 +30,10 @@ import type {
   IGetOpenOrdersRequest,
   IGetOpenOrdersResponse,
   IGetSymbolInfoRequest,
+  IPlaceOrderRequest,
+  IPlaceOrderResponse,
+  IPlaceMarketOrderRequest,
+  IPlaceMarketOrderResponse,
   IPlaceLimitOrderRequest,
   IPlaceLimitOrderResponse,
   IPlaceStopOrderRequest,
@@ -39,8 +43,6 @@ import type {
   IWatchCandlesResponse,
   IWatchOrdersRequest,
   IWatchOrdersResponse,
-  IPlaceMarketOrderRequest,
-  IPlaceMarketOrderResponse,
   ExchangeCode,
   IWatchTradesRequest,
   IWatchTradesResponse,
@@ -105,6 +107,13 @@ export class CCXTExchange implements IExchange {
     const data = await this.ccxt.fetchOrder(...args);
 
     return normalize.getLimitOrder.response(data);
+  }
+
+  async placeOrder(params: IPlaceOrderRequest): Promise<IPlaceOrderResponse> {
+    const args = normalize.placeOrder.request(params);
+    const data = await this.ccxt.createOrder(...args);
+
+    return normalize.placeOrder.response(data);
   }
 
   async placeLimitOrder(params: IPlaceLimitOrderRequest): Promise<IPlaceLimitOrderResponse> {

--- a/packages/exchanges/src/exchanges/ccxt/normalize.ts
+++ b/packages/exchanges/src/exchanges/ccxt/normalize.ts
@@ -131,6 +131,26 @@ const getClosedOrders: Normalize["getClosedOrders"] = {
     })),
 };
 
+const getTicker: Normalize["getTicker"] = {
+  request: (symbol) => [symbol],
+  response: (ticker) => ({
+    symbol: ticker.symbol!,
+    timestamp: ticker.timestamp!,
+
+    bid: ticker.bid!,
+    ask: ticker.ask!,
+    last: ticker.last!,
+
+    open: ticker.open,
+    high: ticker.high,
+    low: ticker.low,
+    close: ticker.close,
+
+    baseVolume: ticker.baseVolume!,
+    quoteVolume: ticker.quoteVolume!,
+  }),
+};
+
 const getMarketPrice: Normalize["getMarketPrice"] = {
   request: (params) => [params.symbol],
   response: (ticker) => ({
@@ -264,6 +284,7 @@ export const normalize: Normalize = {
   cancelLimitOrder,
   getOpenOrders,
   getClosedOrders,
+  getTicker,
   getMarketPrice,
   getCandlesticks,
   getSymbol,

--- a/packages/exchanges/src/exchanges/ccxt/normalize.ts
+++ b/packages/exchanges/src/exchanges/ccxt/normalize.ts
@@ -1,5 +1,6 @@
+import { type OrderType } from "ccxt";
 import { composeSymbolIdFromPair, getExponentAbs } from "@opentrader/tools";
-import { OrderSide } from "@opentrader/types";
+import { OrderSide, XOrderType } from "@opentrader/types";
 import type { Normalize } from "../../types/normalize.interface.js";
 import { normalizeOrderStatus } from "../../utils/normalizeOrderStatus.js";
 
@@ -33,6 +34,24 @@ const getLimitOrder: Normalize["getLimitOrder"] = {
     fee: order.fee?.cost || 0,
     createdAt: order.timestamp,
     lastTradeTimestamp: order.lastTradeTimestamp,
+  }),
+};
+
+const placeOrder: Normalize["placeOrder"] = {
+  request: (params) => {
+    const orderType: OrderType = params.type === XOrderType.Market ? "market" : "limit";
+
+    // Some exchanges require price for Market orders to calculate the total cost of the order in the quote currency.
+    // https://docs.ccxt.com/#/?id=market-buys
+    if (params.price !== undefined) {
+      return [params.symbol, orderType, params.side, params.quantity, params.price];
+    }
+
+    return [params.symbol, orderType, params.side, params.quantity];
+  },
+  response: (order) => ({
+    orderId: order.id,
+    clientOrderId: order.clientOrderId,
   }),
 };
 
@@ -238,6 +257,7 @@ const watchTicker: Normalize["watchTicker"] = {
 export const normalize: Normalize = {
   accountAssets,
   getLimitOrder,
+  placeOrder,
   placeLimitOrder,
   placeMarketOrder,
   placeStopOrder,

--- a/packages/exchanges/src/exchanges/ccxt/paper-exchange.ts
+++ b/packages/exchanges/src/exchanges/ccxt/paper-exchange.ts
@@ -38,6 +38,8 @@ import {
   OrderSide,
   OrderStatus,
   OrderType,
+  IPlaceOrderRequest,
+  IPlaceOrderResponse,
 } from "@opentrader/types";
 import { PaperOrder, xprisma } from "@opentrader/db";
 import { CCXTExchange } from "./exchange.js";
@@ -204,6 +206,17 @@ export class PaperExchange extends CCXTExchange {
       lastTradeTimestamp: order.lastTradeTimestamp.getTime(),
       exchangeOrderId: `${order.id}`,
     };
+  }
+
+  async placeOrder(params: IPlaceOrderRequest): Promise<IPlaceOrderResponse> {
+    if (params.type === OrderType.Market) {
+      const price = params.price;
+      if (price === undefined) throw new Error("PaperExchange: Limit orders require a price param");
+
+      return this.placeLimitOrder({ ...params, price });
+    } else {
+      return this.placeMarketOrder(params);
+    }
   }
 
   /**

--- a/packages/exchanges/src/types/exchange.interface.ts
+++ b/packages/exchanges/src/types/exchange.interface.ts
@@ -52,6 +52,7 @@ export interface IExchange {
   placeStopOrder: (body: IPlaceStopOrderRequest) => Promise<IPlaceStopOrderResponse>;
   getOpenOrders: (body: IGetOpenOrdersRequest) => Promise<IGetOpenOrdersResponse>;
   getClosedOrders: (body: IGetClosedOrdersRequest) => Promise<IGetClosedOrdersResponse>;
+  getTicker: (symbol: string) => Promise<ITicker>;
   getMarketPrice: (params: IGetMarketPriceRequest) => Promise<IGetMarketPriceResponse>;
   getCandlesticks: (params: IGetCandlesticksRequest) => Promise<ICandlestick[]>;
   getSymbols: () => Promise<ISymbolInfo[]>;

--- a/packages/exchanges/src/types/exchange.interface.ts
+++ b/packages/exchanges/src/types/exchange.interface.ts
@@ -8,22 +8,24 @@ import {
   ICancelLimitOrderResponse,
   IGetLimitOrderRequest,
   IGetLimitOrderResponse,
-  IPlaceLimitOrderRequest,
-  IPlaceLimitOrderResponse,
   ISymbolInfo,
   IGetSymbolInfoRequest,
   IGetOpenOrdersRequest,
   IGetOpenOrdersResponse,
   IGetClosedOrdersRequest,
   IGetClosedOrdersResponse,
-  IWatchOrdersRequest,
-  IWatchOrdersResponse,
-  IPlaceStopOrderRequest,
-  IPlaceStopOrderResponse,
-  ExchangeCode,
-  IWatchCandlesRequest,
+  IPlaceOrderRequest,
+  IPlaceOrderResponse,
+  IPlaceLimitOrderRequest,
+  IPlaceLimitOrderResponse,
   IPlaceMarketOrderRequest,
   IPlaceMarketOrderResponse,
+  IPlaceStopOrderRequest,
+  IPlaceStopOrderResponse,
+  IWatchOrdersRequest,
+  IWatchOrdersResponse,
+  ExchangeCode,
+  IWatchCandlesRequest,
   IWatchTradesRequest,
   IWatchTradesResponse,
   IOrderbook,
@@ -43,6 +45,7 @@ export interface IExchange {
 
   accountAssets: () => Promise<IAccountAsset[]>;
   getLimitOrder: (body: IGetLimitOrderRequest) => Promise<IGetLimitOrderResponse>;
+  placeOrder: (body: IPlaceOrderRequest) => Promise<IPlaceOrderResponse>;
   placeLimitOrder: (body: IPlaceLimitOrderRequest) => Promise<IPlaceLimitOrderResponse>;
   placeMarketOrder: (boyd: IPlaceMarketOrderRequest) => Promise<IPlaceMarketOrderResponse>;
   cancelLimitOrder: (body: ICancelLimitOrderRequest) => Promise<ICancelLimitOrderResponse>;

--- a/packages/exchanges/src/types/normalize.interface.ts
+++ b/packages/exchanges/src/types/normalize.interface.ts
@@ -82,6 +82,11 @@ export type Normalize = {
     response: (data: Order[]) => IGetClosedOrdersResponse;
   };
 
+  getTicker: {
+    request: (symbol: string) => Parameters<Exchange["fetchTicker"]>;
+    response: (data: Ticker) => ITicker;
+  };
+
   getMarketPrice: {
     request: (params: IGetMarketPriceRequest) => Parameters<Exchange["fetchTicker"]>;
     response: (data: Ticker) => IGetMarketPriceResponse;

--- a/packages/exchanges/src/types/normalize.interface.ts
+++ b/packages/exchanges/src/types/normalize.interface.ts
@@ -13,8 +13,12 @@ import type {
   IGetMarketPriceRequest,
   IGetMarketPriceResponse,
   IGetSymbolInfoRequest,
+  IPlaceOrderRequest,
+  IPlaceOrderResponse,
   IPlaceLimitOrderRequest,
   IPlaceLimitOrderResponse,
+  IPlaceMarketOrderRequest,
+  IPlaceMarketOrderResponse,
   ISymbolInfo,
   IWatchOrdersRequest,
   IWatchOrdersResponse,
@@ -22,8 +26,6 @@ import type {
   IPlaceStopOrderResponse,
   IWatchCandlesRequest,
   IWatchCandlesResponse,
-  IPlaceMarketOrderRequest,
-  IPlaceMarketOrderResponse,
   ExchangeCode,
   IWatchTradesRequest,
   IWatchTradesResponse,
@@ -41,6 +43,11 @@ export type Normalize = {
   getLimitOrder: {
     request: (params: IGetLimitOrderRequest) => Parameters<Exchange["fetchOrder"]>;
     response: (data: Order) => IGetLimitOrderResponse;
+  };
+
+  placeOrder: {
+    request: (params: IPlaceOrderRequest) => Parameters<Exchange["createOrder"]>;
+    response: (data: Order) => IPlaceOrderResponse;
   };
 
   placeLimitOrder: {

--- a/packages/types/src/exchange/index.ts
+++ b/packages/types/src/exchange/index.ts
@@ -9,6 +9,7 @@ export * from "./public-data/get-symbols-info.js";
 export * from "./trade/common/enums.js";
 export * from "./trade/cancel-limit-order.js";
 export * from "./trade/get-limit-order.js";
+export * from "./trade/place-order.js";
 export * from "./trade/place-limit-order.js";
 export * from "./trade/place-market-order.js";
 export * from "./trade/place-stop-order.js";

--- a/packages/types/src/exchange/trade/place-market-order.ts
+++ b/packages/types/src/exchange/trade/place-market-order.ts
@@ -2,7 +2,7 @@ import type { OrderSide } from "./common/enums.js";
 
 export interface IPlaceMarketOrderRequest {
   /**
-   * Instrument ID, e.g `ADA-USDT`.
+   * Instrument ID, e.g `BTC/USDT`.
    */
   symbol: string;
   /**

--- a/packages/types/src/exchange/trade/place-order.ts
+++ b/packages/types/src/exchange/trade/place-order.ts
@@ -1,0 +1,38 @@
+import { XOrderType } from "../../common/index.js";
+import type { OrderSide } from "./common/enums.js";
+
+export interface IPlaceOrderRequest {
+  /**
+   * Order type: Limit | Market
+   */
+  type: XOrderType;
+  /**
+   * Instrument ID, e.g `BTC/USDT`.
+   */
+  symbol: string;
+  /**
+   * Client-supplied order ID
+   */
+  clientOrderId?: string;
+  side: OrderSide;
+  /**
+   * Quantity to buy or sell.
+   */
+  quantity: number;
+  /**
+   * Some exchanges require price for Market orders to calculate the total cost of the order in the quote currency.
+   * @see https://docs.ccxt.com/#/?id=market-buys
+   */
+  price?: number;
+}
+
+export interface IPlaceOrderResponse {
+  /**
+   * Order ID.
+   */
+  orderId: string;
+  /**
+   * Client-supplied order ID
+   */
+  clientOrderId?: string;
+}


### PR DESCRIPTION
- **Exchange**: Added unified method `placeOrder` for placing both Limit and Market orders
- **Exchange**: Added `getTicker` method
- **OrderExecutor**: Estimate Market buy order price using ticker data