### PR TITLE
docs: update CONTRIBUTING.md to show Commit Message Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,9 +130,8 @@ moon run backend:dev
 - Indicators: [packages/indicators](/packages/indicators/src/indicators)
 - Exchange connectors: [packages/exchanges](/packages/exchanges/src/exchanges)
 
-# Conventional Commits Reference
+# Conventional Commits
 
-The reference link https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-
+Please follow the [Conventional Commits](https://conventionalcommits.org) standard to keep commit messages clear, consistent, and meaningful.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,72 +130,9 @@ moon run backend:dev
 - Indicators: [packages/indicators](/packages/indicators/src/indicators)
 - Exchange connectors: [packages/exchanges](/packages/exchanges/src/exchanges)
 
-# Commit Message Guidelines
-As a contributor, squash feature branches onto 'dev' and write a standardized commit message while doing so.
-Each commit message consists of a header, a body and a footer. The header has a special format that includes a type, a scope and a subject:
+# Conventional Commits: Specification & Reference
 
-```bash
-<type>[optional scope]: <description>
+Use Conventional Commits https://www.conventionalcommits.org/en/v1.0.0-beta.2/
 
-[optional body]
 
-[optional footer]
-```
-The commit contains the following structural elements:
-1. Commit `Type`
-- **fix:** A commit of type `fix` patches a bug in your codebase.
-- **feat:** A commit of the type `feat` introduces a new feature to the codebase.
-- **docs:** Documentation only changes
-- **perf:** A code change that improves performance
-- **refactor:** A code change that neither fixes a bug nor adds a feature
-- **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-- **test:** Adding missing tests or correcting existing tests
 
-2. Commit `Scope`
-A scope may be provided to a commit’s type. The following is the list of supported scopes:
-- **backtesting**
-- **bot**
-- **daemon**
-- **db**
-- **eslint**
-- **event-bus**
-- **exchanges**
-- **indicators**
-- **logger**
-- **prisma**
-- **processing**
-- **tools**
-- **trpc**
-- **tsconfig**
-- **types**
-
-3. Commit `BREAKING CHANGE`
-A commit that has the text BREAKING CHANGE: at the beginning of its optional body or footer section introduces a breaking API change (correlating with MAJOR in semantic versioning).
-A breaking change can be part of commits of any type. e.g., a fix:, & feat: types would all be valid, in addition to any other type.
-
-4. Commit `SAMPLES`
-- Commit message with description and breaking change in body
-```bash
-feat: allow provided config object to extend other configs
-
-BREAKING CHANGE: `extends` key in config file is now used for extending other config files
-```
-
-- Commit message with no body
-```bash
-docs: correct spelling of CHANGELOG
-```
-
-- Commit message with scope
-```bash
-feat(lang): added polish language
-```
-
-- Commit message for a fix using an (optional) issue number.
-```bash
-fix: minor typos in code
-
-see the issue for details on the typos fixed
-
-fixes issue #12
-```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,9 +130,9 @@ moon run backend:dev
 - Indicators: [packages/indicators](/packages/indicators/src/indicators)
 - Exchange connectors: [packages/exchanges](/packages/exchanges/src/exchanges)
 
-# Conventional Commits: Specification & Reference
+# Conventional Commits Reference
 
-Use Conventional Commits https://www.conventionalcommits.org/en/v1.0.0-beta.2/
+The reference link https://www.conventionalcommits.org/en/v1.0.0-beta.2/
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,3 +129,73 @@ moon run backend:dev
 - Strategies dir: [packages/bot-templates](/packages/bot-templates/src/templates)
 - Indicators: [packages/indicators](/packages/indicators/src/indicators)
 - Exchange connectors: [packages/exchanges](/packages/exchanges/src/exchanges)
+
+# Commit Message Guidelines
+As a contributor, squash feature branches onto 'dev' and write a standardized commit message while doing so.
+Each commit message consists of a header, a body and a footer. The header has a special format that includes a type, a scope and a subject:
+
+```bash
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer]
+```
+The commit contains the following structural elements:
+1. Commit `Type`
+- **fix:** A commit of type `fix` patches a bug in your codebase.
+- **feat:** A commit of the type `feat` introduces a new feature to the codebase.
+- **docs:** Documentation only changes
+- **perf:** A code change that improves performance
+- **refactor:** A code change that neither fixes a bug nor adds a feature
+- **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test:** Adding missing tests or correcting existing tests
+
+2. Commit `Scope`
+A scope may be provided to a commit’s type. The following is the list of supported scopes:
+- **backtesting**
+- **bot**
+- **daemon**
+- **db**
+- **eslint**
+- **event-bus**
+- **exchanges**
+- **indicators**
+- **logger**
+- **prisma**
+- **processing**
+- **tools**
+- **trpc**
+- **tsconfig**
+- **types**
+
+3. Commit `BREAKING CHANGE`
+A commit that has the text BREAKING CHANGE: at the beginning of its optional body or footer section introduces a breaking API change (correlating with MAJOR in semantic versioning).
+A breaking change can be part of commits of any type. e.g., a fix:, & feat: types would all be valid, in addition to any other type.
+
+4. Commit `SAMPLES`
+- Commit message with description and breaking change in body
+```bash
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+- Commit message with no body
+```bash
+docs: correct spelling of CHANGELOG
+```
+
+- Commit message with scope
+```bash
+feat(lang): added polish language
+```
+
+- Commit message for a fix using an (optional) issue number.
+```bash
+fix: minor typos in code
+
+see the issue for details on the typos fixed
+
+fixes issue #12
+```


### PR DESCRIPTION
The UI result look likes as the screenshot below

![image](https://github.com/user-attachments/assets/3116f1db-828a-4334-95b5-9a769b3eb9dc)
![image](https://github.com/user-attachments/assets/398acde9-f32a-4cf0-9326-d245cfdadecc)
