### PR TITLE
feat(FundsValidation): implement funds validation service #105

### DIFF
--- a/packages/bot-processor/src/types/bot/bot-template.type.ts
+++ b/packages/bot-processor/src/types/bot/bot-template.type.ts
@@ -52,6 +52,36 @@ export interface BotTemplate<T extends IBotConfiguration> {
    */
   hidden?: boolean;
   /**
+   * Funds required to run the strategy. Can be a static object defining required amounts
+   * for each currency, or a function that calculates required funds based on bot configuration.
+   * 
+   * @example Static funds requirement
+   * ```ts
+   * strategy.fundsRequired = {
+   *   ETH: 1,
+   *   USDT: 100
+   * }
+   * ```
+   * 
+   * @example Dynamic funds requirement
+   * ```ts
+   * strategy.fundsRequired = (bot) => ({
+   *   ETH: bot.settings.quantity,
+   *   USDT: bot.settings.quantity * bot.settings.price
+   * })
+   * ```
+   * 
+   * @example Skip funds validation for certain conditions
+   * ```ts
+   * strategy.fundsRequired = (bot) => {
+   *   // Skip validation for market orders where price is unknown
+   *   if (!bot.settings.price) return undefined;
+   *   return { USDT: bot.settings.quantity * bot.settings.price };
+   * }
+   * ```
+   */
+  fundsRequired?: Record<string, number> | ((botConfig: T) => Record<string, number> | undefined);
+  /**
    * List of pairs to watch for trades.
    *
    * @example Watch trades on BTC/USDT pair. The default exchange from bot config will be used.

--- a/packages/bot-templates/src/templates/dca.ts
+++ b/packages/bot-templates/src/templates/dca.ts
@@ -78,6 +78,30 @@ dca.watchers = {
   watchCandles: ({ symbol }: IBotConfiguration) => symbol,
 };
 
+dca.fundsRequired = (botConfig: DCABotConfig) => {
+  const { settings } = botConfig;
+  const baseAsset = botConfig.symbol.split("/")[1] || "USDT";
+
+  // If entry price is not defined (market order), we cannot calculate exact funds needed
+  // Return undefined to skip funds validation for market orders
+  if (!settings.entry.price) {
+    return undefined;
+  }
+
+  const entryPrice = settings.entry.price;
+
+  // Calculate total required funds based on entry quantity and safety orders
+  const entryFunds = settings.entry.quantity * entryPrice;
+  const safetyOrdersFunds = settings.safetyOrders.reduce(
+    (total, so) => total + so.quantity * entryPrice * (1 - so.priceDeviation / 100),
+    0,
+  );
+
+  return {
+    [baseAsset]: entryFunds + safetyOrdersFunds,
+  };
+};
+
 type Template = BotTemplate<DCABotConfig>;
 
 export type DCABotConfig = IBotConfiguration<z.infer<typeof dca.schema>>;

--- a/packages/bot-templates/src/templates/test/index.ts
+++ b/packages/bot-templates/src/templates/test/index.ts
@@ -13,3 +13,4 @@ export * from "./testOrderbook.js";
 export * from "./testTicker.js";
 export * from "./testPublicTrade.js";
 export * from "./testAllEffect.js";
+export * from "./testFundsRequired.js";

--- a/packages/bot-templates/src/templates/test/testFundsRequired.ts
+++ b/packages/bot-templates/src/templates/test/testFundsRequired.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { logger } from "@opentrader/logger";
+import { BarSize } from "@opentrader/types";
+import {
+  buy,
+  sell,
+  IBotConfiguration,
+  TBotContext,
+  BotTemplate,
+} from "@opentrader/bot-processor";
+
+const ExampleStrategySchema = z.object({
+  quantity: z.number().min(0.001),
+});
+
+export function* exampleStrategy(ctx: TBotContext<ExampleStrategyBotConfig>) {
+  const { config, onStart, onStop } = ctx;
+  const { settings } = config;
+
+  if (onStop) {
+    logger.info(`[ExampleStrategy] Bot with ${config.symbol} pair stopped`);
+    return;
+  }
+
+  if (onStart) {
+    logger.info(`[ExampleStrategy] Bot strategy started on ${config.symbol} pair`);
+    return;
+  }
+
+  // Simple example strategy logic
+  if (Math.random() > 0.5) {
+    yield buy({ quantity: settings.quantity });
+  } else {
+    yield sell({ quantity: settings.quantity });
+  }
+
+  logger.info(`[ExampleStrategy] Strategy executed`);
+}
+
+exampleStrategy.displayName = "Example Strategy";
+exampleStrategy.description = 
+  "A simple example strategy that demonstrates funds requirement validation. " +
+  "It randomly buys or sells with the configured quantity.";
+exampleStrategy.hidden = true; // Hide from UI since it's just an example
+exampleStrategy.schema = ExampleStrategySchema;
+
+exampleStrategy.runPolicy = {
+  onCandleClosed: true,
+} satisfies Template["runPolicy"];
+
+exampleStrategy.timeframe = BarSize.ONE_MINUTE;
+
+exampleStrategy.watchers = {
+  watchCandles: ({ symbol }: IBotConfiguration) => symbol,
+};
+
+// Example of static funds requirement
+exampleStrategy.fundsRequired = {
+  ETH: 1,
+  USDT: 100,
+};
+
+type Template = BotTemplate<ExampleStrategyBotConfig>;
+
+export type ExampleStrategyBotConfig = IBotConfiguration<z.infer<typeof exampleStrategy.schema>>;

--- a/packages/bot-templates/src/utils/funds-validator.ts
+++ b/packages/bot-templates/src/utils/funds-validator.ts
@@ -1,0 +1,129 @@
+import type { IBotConfiguration } from "@opentrader/bot-processor";
+
+/**
+ * Utility functions for handling funds validation in bot templates
+ */
+
+/**
+ * Type for funds requirement - can be static object or dynamic function
+ */
+export type FundsRequirement<T extends IBotConfiguration> = 
+  | Record<string, number>
+  | ((botConfig: T) => Record<string, number>);
+
+/**
+ * Resolves funds requirement from a strategy template
+ * @param fundsRequired - The fundsRequired property from a strategy
+ * @param botConfig - Bot configuration to pass to dynamic functions
+ * @returns Record of currency -> amount required
+ */
+export function resolveFundsRequirement<T extends IBotConfiguration>(
+  fundsRequired: FundsRequirement<T> | undefined,
+  botConfig: T
+): Record<string, number> | undefined {
+  if (!fundsRequired) {
+    return undefined;
+  }
+
+  if (typeof fundsRequired === 'function') {
+    return fundsRequired(botConfig);
+  }
+
+  return fundsRequired;
+}
+
+/**
+ * Validates that a funds requirement object is valid
+ * @param fundsRequired - Funds requirement to validate
+ * @returns Array of validation errors (empty if valid)
+ */
+export function validateFundsRequirement(
+  fundsRequired: Record<string, number>
+): string[] {
+  const errors: string[] = [];
+
+  if (!fundsRequired || typeof fundsRequired !== 'object') {
+    errors.push('Funds requirement must be an object');
+    return errors;
+  }
+
+  for (const [currency, amount] of Object.entries(fundsRequired)) {
+    if (typeof currency !== 'string' || !currency.trim()) {
+      errors.push('Currency keys must be non-empty strings');
+    }
+
+    if (typeof amount !== 'number' || amount < 0 || !isFinite(amount)) {
+      errors.push(`Amount for ${currency} must be a non-negative finite number`);
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Creates a human-readable string from funds requirement
+ * @param fundsRequired - Funds requirement object
+ * @returns Formatted string like "1 ETH, 100 USDT"
+ */
+export function formatFundsRequirement(
+  fundsRequired: Record<string, number>
+): string {
+  return Object.entries(fundsRequired)
+    .map(([currency, amount]) => `${amount} ${currency}`)
+    .join(', ');
+}
+
+/**
+ * Compares two funds objects and returns shortage information
+ * @param required - Required funds
+ * @param available - Available funds  
+ * @returns Object with shortage details
+ */
+export function calculateFundsShortage(
+  required: Record<string, number>,
+  available: Record<string, number>
+): {
+  hasShortage: boolean;
+  shortages: Array<{ currency: string; required: number; available: number; shortage: number }>;
+} {
+  const shortages: Array<{ currency: string; required: number; available: number; shortage: number }> = [];
+
+  for (const [currency, requiredAmount] of Object.entries(required)) {
+    const availableAmount = available[currency] || 0;
+    
+    if (availableAmount < requiredAmount) {
+      shortages.push({
+        currency,
+        required: requiredAmount,
+        available: availableAmount,
+        shortage: requiredAmount - availableAmount,
+      });
+    }
+  }
+
+  return {
+    hasShortage: shortages.length > 0,
+    shortages,
+  };
+}
+
+/**
+ * Helper function to extract currency symbols from a trading pair symbol
+ * Useful for determining what currencies might be needed for trading
+ * @param symbol - Trading pair symbol like "BTC/USDT"
+ * @returns Object with base and quote currencies
+ */
+export function parseSymbolCurrencies(symbol: string): {
+  base: string;
+  quote: string;
+} | null {
+  const parts = symbol.split('/');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  return {
+    base: parts[0],
+    quote: parts[1],
+  };
+}

--- a/packages/trpc/src/routers/private/bot/start-bot/handler.ts
+++ b/packages/trpc/src/routers/private/bot/start-bot/handler.ts
@@ -1,5 +1,6 @@
 import { eventBus } from "@opentrader/event-bus";
 import { BotService } from "../../../../services/bot.service.js";
+import { FundsValidationService } from "../../../../services/funds-validation.service.js";
 import type { Context } from "../../../../utils/context.js";
 import type { TStartGridBotInputSchema } from "./schema.js";
 
@@ -16,6 +17,10 @@ export async function startGridBot({ input }: Options) {
   const botService = await BotService.fromId(botId);
   botService.assertIsNotAlreadyRunning();
   botService.assertIsNotProcessing();
+
+  // Validate funds before starting the bot
+  const fundsValidationService = new FundsValidationService(botService.bot);
+  await fundsValidationService.validateFundsOrThrow();
 
   await eventBus.emit("startBot", botService.bot);
 

--- a/packages/trpc/src/services/funds-validation.service.ts
+++ b/packages/trpc/src/services/funds-validation.service.ts
@@ -1,0 +1,165 @@
+import { TRPCError } from "@trpc/server";
+import type { TBotWithExchangeAccount } from "@opentrader/db";
+import { findStrategy } from "@opentrader/bot-templates/server";
+import { exchangeProvider } from "@opentrader/exchanges";
+import type { IBotConfiguration } from "@opentrader/bot-processor";
+import type { IAccountAsset } from "@opentrader/types";
+
+export interface FundsValidationResult {
+  hasEnoughFunds: boolean;
+  requiredFunds?: Record<string, number>;
+  availableFunds?: Record<string, number>;
+  errorMessage?: string;
+}
+
+export class FundsValidationService {
+  constructor(private bot: TBotWithExchangeAccount) {}
+
+  /**
+   * Validates if the bot has enough funds to run the strategy
+   */
+  async validateFunds(): Promise<FundsValidationResult> {
+    try {
+      // Find the strategy template
+      const { strategyFn } = findStrategy(this.bot.template);
+      
+      // Skip validation if strategy doesn't define fundsRequired
+      if (!strategyFn.fundsRequired) {
+        return { hasEnoughFunds: true };
+      }
+
+      // Get required funds from strategy
+      const requiredFunds = this.getRequiredFunds(strategyFn, this.bot);
+      
+      // Skip validation if strategy returns undefined (e.g., for market orders)
+      if (!requiredFunds) {
+        return { hasEnoughFunds: true };
+      }
+      
+      // Get current portfolio
+      const availableFunds = await this.getAvailableFunds();
+
+      // Check if we have enough funds
+      const validationResult = this.compareFunds(requiredFunds, availableFunds);
+
+      return {
+        hasEnoughFunds: validationResult.hasEnoughFunds,
+        requiredFunds,
+        availableFunds,
+        errorMessage: validationResult.errorMessage,
+      };
+    } catch (error) {
+      return {
+        hasEnoughFunds: false,
+        errorMessage: `Failed to validate funds: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
+  }
+
+  /**
+   * Validates funds and throws an error if insufficient
+   */
+  async validateFundsOrThrow(): Promise<void> {
+    const result = await this.validateFunds();
+    
+    if (!result.hasEnoughFunds) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: result.errorMessage || "Insufficient funds to run the strategy",
+      });
+    }
+  }
+
+  /**
+   * Extracts required funds from strategy template
+   */
+  private getRequiredFunds(
+    strategyFn: any, 
+    bot: TBotWithExchangeAccount
+  ): Record<string, number> | undefined {
+    if (typeof strategyFn.fundsRequired === 'function') {
+      // Create a minimal bot configuration for the function
+      const botConfig: IBotConfiguration = {
+        id: bot.id,
+        symbol: bot.symbol,
+        settings: bot.settings,
+      };
+      
+      return strategyFn.fundsRequired(botConfig);
+    } else {
+      return strategyFn.fundsRequired;
+    }
+  }
+
+  /**
+   * Fetches current account assets from exchange
+   */
+  private async getAvailableFunds(): Promise<Record<string, number>> {
+    // Convert to ExchangeAccountWithCredentials format
+    const exchangeAccountWithCredentials = {
+      ...this.bot.exchangeAccount,
+      credentials: {
+        code: this.bot.exchangeAccount.exchangeCode,
+        apiKey: this.bot.exchangeAccount.apiKey,
+        secretKey: this.bot.exchangeAccount.secretKey,
+        password: this.bot.exchangeAccount.password,
+        isDemoAccount: this.bot.exchangeAccount.isDemoAccount,
+        isPaperAccount: this.bot.exchangeAccount.isPaperAccount,
+      }
+    };
+
+    const exchange = exchangeProvider.fromAccount(exchangeAccountWithCredentials);
+
+    try {
+      const accountAssets: IAccountAsset[] = await exchange.accountAssets();
+      
+      // Convert to a simple currency -> available balance mapping
+      const availableFunds: Record<string, number> = {};
+      
+      for (const asset of accountAssets) {
+        availableFunds[asset.currency] = asset.availableBalance;
+      }
+      
+      return availableFunds;
+    } finally {
+      await exchange.destroy();
+    }
+  }
+
+  /**
+   * Compares required funds with available funds
+   */
+  private compareFunds(
+    requiredFunds: Record<string, number>,
+    availableFunds: Record<string, number>
+  ): { hasEnoughFunds: boolean; errorMessage?: string } {
+    const insufficientCurrencies: string[] = [];
+    const portfolioDetails: string[] = [];
+    const requiredDetails: string[] = [];
+
+    for (const [currency, requiredAmount] of Object.entries(requiredFunds)) {
+      const availableAmount = availableFunds[currency] || 0;
+      
+      portfolioDetails.push(`${availableAmount} ${currency}`);
+      requiredDetails.push(`${requiredAmount} ${currency}`);
+
+      if (availableAmount < requiredAmount) {
+        insufficientCurrencies.push(
+          `${currency}: need ${requiredAmount}, have ${availableAmount}`
+        );
+      }
+    }
+
+    if (insufficientCurrencies.length > 0) {
+      const portfolioStr = portfolioDetails.join(', ');
+      const requiredStr = requiredDetails.join(', ');
+      
+      return {
+        hasEnoughFunds: false,
+        errorMessage: `Not enough funds to run the strategy. Your portfolio: ${portfolioStr}. Required: ${requiredStr}`,
+      };
+    }
+
+    return { hasEnoughFunds: true };
+  }
+}


### PR DESCRIPTION
  ## TLDR

  Implements comprehensive funds validation system that checks if users have sufficient account balance before starting trading bots. The system validates against strategy-defined fund requirements
  and provides detailed error messages when funds are insufficient.

  ## Dive Deeper

  This PR introduces a complete funds validation framework that addresses a critical user experience issue where bots could start without sufficient funds, leading to failed trades and confusion.

  ### Key Components Added:

  1. **Enhanced BotTemplate Interface**: Extended strategy templates to support `fundsRequired` property with both static and dynamic fund calculations
  2. **FundsValidationService**: Core service that fetches account balance, parses strategy requirements, and validates sufficiency
  3. **Flexible Validation Logic**:
     - Supports static fund requirements: `{ ETH: 1, USDT: 100 }`
     - Supports dynamic calculations: `(bot) => ({ ETH: bot.settings.quantity })`
     - Gracefully handles market orders by returning `undefined` to skip validation
  4. **Integration with Bot Startup**: Seamlessly integrated into the existing bot start workflow

  ### Error Handling:
  - Provides detailed error messages showing current portfolio vs required funds
  - Format: "Not enough funds to run the strategy. Your portfolio: 0.5 ETH, 50 USDT. Required: 1 ETH, 100 USDT"
  - Prevents bot startup when funds are insufficient

  ### Strategy Examples:
  - Updated DCA strategy with dynamic fund calculation based on entry orders and safety orders
  - Added test strategy demonstrating static fund requirements
  - Handles edge cases like undefined prices (market orders)

  ## Reviewer Test Plan

  ### Setup:
  1. Pull the branch and run `npm install`
  2. Start the development environment with `npm run dev`
  3. Ensure you have a configured exchange account with some test funds

  ### Testing Scenarios:

  #### 1. **Test Fund Validation Success**
  - Create a DCA bot with small quantities (e.g., 0.001 ETH entry, 1 safety order)
  - Ensure your exchange account has sufficient USDT balance (check calculated requirements)
  - Click "Start Bot" - should succeed without errors
  - Verify bot status changes to "Running"

  #### 2. **Test Fund Validation Failure**
  - Create a DCA bot with large quantities requiring more funds than available
  - Set entry quantity to 10 ETH with multiple safety orders
  - Click "Start Bot" - should fail with detailed error message
  - Error should show: "Not enough funds to run the strategy. Your portfolio: [actual]. Required: [calculated]"

  #### 3. **Test Strategy Without Fund Requirements**
  - Use any strategy template that doesn't define `fundsRequired` (most existing strategies)
  - Start the bot - should work normally (validation is skipped)
  - No fund validation errors should appear

  #### 4. **Test Market Order Handling**
  - Create a DCA bot but set entry type to "Market" (no price specified)
  - Start the bot - should succeed (validation skipped for market orders)
  - Verify no fund validation is performed when price is undefined

  #### 5. **Test Dynamic Fund Calculation**
  - Create DCA bots with different configurations:
    - Vary entry quantity (0.1 vs 1.0 ETH)
    - Adjust safety order count and deviations
  - Check that fund requirements change accordingly
  - Verify calculations include both entry and all safety orders

  Linked issues / bugs

  Closes #105