### PR TITLE
feat: add Coinmate exchange support

### DIFF
--- a/packages/exchanges/src/client/constants.ts
+++ b/packages/exchanges/src/client/constants.ts
@@ -1,4 +1,4 @@
-import { pro as ccxt } from "ccxt";
+import { exchanges as ccxt } from "ccxt";
 import { ExchangeCode } from "@opentrader/types";
 
 /**
@@ -11,12 +11,13 @@ import { ExchangeCode } from "@opentrader/types";
 /**
  * Map exchange code to CCXT instance class name
  */
-export const exchangeCodeMapCCXT: Record<ExchangeCode, keyof typeof ccxt> = {
+export const exchangeCodeMapCCXT: Record<ExchangeCode, string> = {
   [ExchangeCode.OKX]: "okx",
   [ExchangeCode.BYBIT]: "bybit",
   [ExchangeCode.BITGET]: "bitget",
   [ExchangeCode.BINANCE]: "binance",
   [ExchangeCode.KRAKEN]: "kraken",
   [ExchangeCode.COINBASE]: "coinbase",
+  [ExchangeCode.COINMATE]: "coinmate",
   [ExchangeCode.GATEIO]: "gateio",
 };

--- a/packages/exchanges/src/exchanges/ccxt/exchange.ts
+++ b/packages/exchanges/src/exchanges/ccxt/exchange.ts
@@ -87,7 +87,7 @@ export class CCXTExchange implements IExchange {
     this.ccxt =
       ccxtClassName in pro
         ? new pro[ccxtClassName as keyof typeof pro](ccxtCredentials)
-        : new exchanges[ccxtClassName](ccxtCredentials);
+        : new exchanges[ccxtClassName as keyof typeof exchanges](ccxtCredentials);
 
     this.ccxt.fetchImplementation = fetcher; // #57
     // #88 Fixes: 'e instanceof this.AbortError' is not an object

--- a/packages/exchanges/src/exchanges/index.ts
+++ b/packages/exchanges/src/exchanges/index.ts
@@ -9,6 +9,7 @@ export const exchanges: Record<ExchangeCode, ReturnType<typeof createExchange>> 
   [ExchangeCode.BINANCE]: createExchange(ExchangeCode.BINANCE),
   [ExchangeCode.KRAKEN]: createExchange(ExchangeCode.KRAKEN),
   [ExchangeCode.COINBASE]: createExchange(ExchangeCode.COINBASE),
+  [ExchangeCode.COINMATE]: createExchange(ExchangeCode.COINMATE),
   [ExchangeCode.GATEIO]: createExchange(ExchangeCode.GATEIO),
 } as const;
 

--- a/packages/types/src/common/enums.ts
+++ b/packages/types/src/common/enums.ts
@@ -18,6 +18,7 @@ export const ExchangeCode = {
   BINANCE: "BINANCE",
   KRAKEN: "KRAKEN",
   COINBASE: "COINBASE",
+  COINMATE: "COINMATE",
   GATEIO: "GATEIO",
   BITGET: "BITGET",
 } as const;


### PR DESCRIPTION
Add Coinmate exchange support.

Changes:
- Add COINMATE to ExchangeCode enum
- Add coinmate to exchangeCodeMapCCXT mapping  
- Register Coinmate in exchanges registry
- Change import from 'pro' to 'exchanges' to include all CCXT exchanges
- Use string type for exchangeCodeMapCCXT to avoid keyof union limitations

Coinmate is available in ccxt.exchanges but not in ccxt.pro. The existing fallback logic in CCXTExchange handles this correctly.